### PR TITLE
Fixes issue #16 from PornHub adding HTTP Live Streaming video formats

### DIFF
--- a/src/lib/scrapy.js
+++ b/src/lib/scrapy.js
@@ -108,18 +108,24 @@ const parseDownloadInfo = (bodyStr) => {
     return info;
   }
 
-  let begin, end;
+  let begin = [], end = [];
   for (let i = idx; i < bodyStr.length; i++) {
     const tmpStr = bodyStr.substr(i, 1);
     if (tmpStr === '[') {
-      begin = i;
+      begin.push(i);
     }
 
     if (tmpStr === ']') {
-      end = i;
-      break;
+      end.push(i);
+
+      if (begin.length === end.length) {
+        break;
+      }
     }
   }
+
+  begin = begin.shift();
+  end = end.pop();
 
   if (begin >= 0 && end >= 0) {
     const jsonStr = bodyStr.substring(begin, end + 1);

--- a/src/lib/scrapy.js
+++ b/src/lib/scrapy.js
@@ -131,7 +131,7 @@ const parseDownloadInfo = (bodyStr) => {
     const jsonStr = bodyStr.substring(begin, end + 1);
     let arr = JSON.parse(jsonStr);
     arr = _.filter(arr, item => {
-      return item.videoUrl.length > 0;
+      return item.videoUrl.length > 0 && item.format !== 'hls';
     });
     arr = _.orderBy(arr, 'quality', 'desc');
     if (arr.length > 0) {


### PR DESCRIPTION
Fixes issue #16 by handling nested brackets when parsing JSON data for the mediaDefinitions array, and excluding hls formats from the download options, which cannot be downloaded the same way.